### PR TITLE
(choco-upgrade-all-at) SchTasks improvements

### DIFF
--- a/choco-upgrade-all-at/choco-upgrade-all-at.nuspec
+++ b/choco-upgrade-all-at/choco-upgrade-all-at.nuspec
@@ -21,6 +21,14 @@
 This script simply sets up a Windows Scheduled Task to run run "choco upgrade all" every day at a predefined time (see package name for time).
 
 Is this miraculous? No. Is this something you could have just done yourself in a minute or two? Yes. Why bother? Because it helps you keep your software up to date easily and you can throw it in a batchfile with the rest of your programs that you use Chocolatey to install. :)
+	    
+### Package Specific
+
+#### Package Parameters
+This package accepts a single optional parameter to specify the time the daily task should run.  This should be in the 24-hour format with a colon separating the hour and minute (ex. 15:30).
+
+This parameter can be passed to the installer with the use of `--params`.
+For example: `choco install choco-upgrade-all-at --params '"20:15"'`.
 	</description>
     <releaseNotes></releaseNotes>
   </metadata>

--- a/choco-upgrade-all-at/choco-upgrade-all-at.nuspec
+++ b/choco-upgrade-all-at/choco-upgrade-all-at.nuspec
@@ -20,7 +20,7 @@
 
 This script simply sets up a Windows Scheduled Task to run run "choco upgrade all" every day at a predefined time (see package name for time).
 
-Is this miraculous? No. Is this something you could have just done yourself in a minute or two? Yes. Why bother? Because it helps you keep your software up to date easily and you can throw it in a batchfile with the rest of your programs that you use Chocolatey to install. The use of the [Elavate tool](https://chocolatey.org/packages/elevate) means that it gets around that UAC problem you had when you tried to do it before. ! :)
+Is this miraculous? No. Is this something you could have just done yourself in a minute or two? Yes. Why bother? Because it helps you keep your software up to date easily and you can throw it in a batchfile with the rest of your programs that you use Chocolatey to install. :)
 	</description>
     <releaseNotes></releaseNotes>
   </metadata>

--- a/choco-upgrade-all-at/choco-upgrade-all-at.nuspec
+++ b/choco-upgrade-all-at/choco-upgrade-all-at.nuspec
@@ -23,9 +23,6 @@ This script simply sets up a Windows Scheduled Task to run run "choco upgrade al
 Is this miraculous? No. Is this something you could have just done yourself in a minute or two? Yes. Why bother? Because it helps you keep your software up to date easily and you can throw it in a batchfile with the rest of your programs that you use Chocolatey to install. The use of the [Elavate tool](https://chocolatey.org/packages/elevate) means that it gets around that UAC problem you had when you tried to do it before. ! :)
 	</description>
     <releaseNotes></releaseNotes>
-    <dependencies>
-      <dependency id="elevate" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/choco-upgrade-all-at/tools/chocolateyinstall.ps1
+++ b/choco-upgrade-all-at/tools/chocolateyinstall.ps1
@@ -8,4 +8,4 @@ if ($PassedParameter) {
 	  }
 
 Write-Host "Now configured to run choco upgrade all at $Runtime every day."
-SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "choco upgrade all" /ST $RunTime /F
+SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "choco upgrade all --confirm" /ST $RunTime /F

--- a/choco-upgrade-all-at/tools/chocolateyinstall.ps1
+++ b/choco-upgrade-all-at/tools/chocolateyinstall.ps1
@@ -8,4 +8,4 @@ if ($PassedParameter) {
 	  }
 
 Write-Host "Now configured to run choco upgrade all at $Runtime every day."
-SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "el choco upgrade all" /ST $RunTime /F
+SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "choco upgrade all" /ST $RunTime /F

--- a/choco-upgrade-all-at/tools/chocolateyinstall.ps1
+++ b/choco-upgrade-all-at/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$PassedParameter = $env:chocolateyPackageParameters
 
 if ($PassedParameter) {
-    $RunTime = $PassedParameter
+    $RunTime = $($PassedParameter)
 	} else {
 	  Write-Host "No time specified, defaulting to midnight."
 	  $RunTime         = '00:00'

--- a/choco-upgrade-all-at/tools/chocolateyinstall.ps1
+++ b/choco-upgrade-all-at/tools/chocolateyinstall.ps1
@@ -8,4 +8,4 @@ if ($PassedParameter) {
 	  }
 
 Write-Host "Now configured to run choco upgrade all at $Runtime every day."
-SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "el choco upgrade all" /ST $RunTime
+SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "el choco upgrade all" /ST $RunTime /F

--- a/choco-upgrade-all-at/tools/chocolateyinstall.ps1
+++ b/choco-upgrade-all-at/tools/chocolateyinstall.ps1
@@ -8,4 +8,4 @@ if ($PassedParameter) {
 	  }
 
 Write-Host "Now configured to run choco upgrade all at $Runtime every day."
-SchTasks /Create /SC DAILY /TN "choco upgrade all at" /TR "el choco upgrade all" /ST $RunTime
+SchTasks /Create /SC DAILY /RU SYSTEM /RL HIGHEST /TN "choco upgrade all at" /TR "el choco upgrade all" /ST $RunTime


### PR DESCRIPTION
These commits:

- Add /F to SchTasks to prevent a potential execution-halting prompt
- Set the task to run elevated as SYSTEM using native Scheduled Task options, removing the need for the external 'elevate' utility
- Remove the nuspec 'elevate' dependency that is no longer required