### PR TITLE
Add missing 64-bit install for irfanviewplugins

### DIFF
--- a/irfanviewplugins/tools/chocolateyInstall.ps1
+++ b/irfanviewplugins/tools/chocolateyInstall.ps1
@@ -14,6 +14,7 @@ $packageArgs = @{
   packageName   = $packageName
   fileType      = $installerType
   url           = $url
+  url64bit      = $url64
   validExitCodes= $validExitCodes
   silentArgs    = $silentArgs
   softwareName  = ''


### PR DESCRIPTION
irfanviewplugins was installing a 32-bit version of itself even though a 64-bit is available (and downloaded). The root cause is a missing entry (`url64bit`) from the `$packageArgs` dictionary.

The irfanviewplugins package must be installed next to irfanview with the same exact architecture; otherwise, the plugins aren't loaded (and everything behaves as if the plugins simply weren't there). Chocolatey installs 64-bit irfanview by default, so it should do the same for irfanviewplugins. The default can be overridden by passing `--x86` when calling `choco install` once this fix is merged.