### PR TITLE
openHAB: don't download the addons file

### DIFF
--- a/openhab/tools/ChocolateyInstall.ps1
+++ b/openhab/tools/ChocolateyInstall.ps1
@@ -27,16 +27,16 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 
-$packageArgs = @{
-  packageName   = $packageName
-  fileType      = ''
-  url           = $url2
-  FileFullPath  = $FileFullpath
-  checksum      = $checksum2
-  checksumType  = 'sha256'
-}
+# $packageArgs = @{
+#   packageName   = $packageName
+#   fileType      = ''
+#   url           = $url2
+#   FileFullPath  = $FileFullpath
+#   checksum      = $checksum2
+#   checksumType  = 'sha256'
+# }
 
-Get-ChocolateyWebFile @packageArgs
+# Get-ChocolateyWebFile @packageArgs
 
 New-Item "$toolsDir\openHAB" -type directory -force -ErrorAction SilentlyContinue
 Install-ChocolateyShortcut -shortcutFilePath "$env:Public\Desktop\$ShortcutName" -targetPath "$toolsDir\openHAB" -WorkingDirectory "$toolsDir\openHAB" -IconLocation "$toolsDir\openHAB.ico"


### PR DESCRIPTION
Downloading the full addons file causes problems, see https://github.com/openhab/website/issues/115.
It is optional anyway (addons can be downloaded on-demand by the runtime), so this temporarily disables it.