### PR TITLE
(hexamail) Simplify package

### DIFF
--- a/hexamail-pop3-downloader/tools/ChocolateyInstall.ps1
+++ b/hexamail-pop3-downloader/tools/ChocolateyInstall.ps1
@@ -5,21 +5,16 @@ $bits           = Get-ProcessorBits
 $url            = 'https://www.hexamail.com/download/hexamailpop3downloadersetup5.9.16.002_64.exe'
 $checksum       = '9D6A8BAC6197FD2210E134AB2E5A8487333C1460D7C7EA040C435E9D2FD9C5AC'
 
-if (!($bits -eq 64)){
-    Write-Warning "  **  This package is for 64 bit versions of Windows only. Aborting..."
-	throw
-	}
-
 $packageArgs = @{
   packageName    = $packageName
   unzipLocation  = $toolsDir  
   fileType       = 'EXE'
-  url            = $url
+  url64bit       = $url
   validExitCodes = @(0,1)
   silentArgs     = '/Q'
   softwareName   = 'Hexamail POP3 Downloader*'
-  checksum       = $checksum
-  checksumType   = 'sha256' 
+  checksum64     = $checksum
+  checksumType64 = 'sha256' 
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Rather than unnecessarily handle whether or not a package is being
installed on a 64bit machine or not, let Chocolatey do that work by
only providing the 64bit properties.