### PR TITLE
(osfmount) Simplify package

### DIFF
--- a/osfmount/tools/chocolateyinstall.ps1
+++ b/osfmount/tools/chocolateyinstall.ps1
@@ -5,21 +5,12 @@ $bits        = Get-ProcessorBits
 $url         = 'http://www.osforensics.com/downloads/osfmount.exe'
 $checksum    = '5348838DD60607057DBD1448E5173D1C4C6280B82AFE9967A837499822FC8C5D'
 
-if ($bits -eq 32)
-   {
-	Write-Host "  ** OSFMount v3+ is 64 bit only. Please try v2. Aborting." -Foreground Red
-	throw
-   }
-
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
-  fileType      = 'exe' 
-  url           = $url
-  checksum      = $checksum
-  checksumType  = 'sha256'  
-  url64bit      = $url64
-  checksum64    = $checksum64
+  fileType      = 'exe'  
+  url64bit      = $url
+  checksum64    = $checksum
   checksumType64= 'sha256'
   silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' 
   softwareName  = 'OSFMount*' 


### PR DESCRIPTION
Rather than unnecessarily handle whether or not a package is being
installed on a 64bit machine or not, let Chocolatey do that work by
only providing the 64bit properties.