### PR TITLE
jellyfin: update to 10.5.4

### DIFF
--- a/jellyfin/jellyfin.nuspec
+++ b/jellyfin/jellyfin.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jellyfin</id>
-    <version>10.4.2</version>
+    <version>10.5.4</version>
     <title>Jellyfin (Install)</title>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/jellyfin</packageSourceUrl>

--- a/jellyfin/tools/chocolateyInstall.ps1
+++ b/jellyfin/tools/chocolateyInstall.ps1
@@ -1,37 +1,32 @@
 ﻿$ErrorActionPreference = 'Stop'
-$packageName  = 'jellyfin'
+$version = "v$ENV:ChocolateyPackageVersion"
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$installer    = "jellyfin_v$ENV:ChocolateyPackageVersion-x64.exe"
 $ShortcutName = 'Jellyfin'
-$exe          = 'jellyfin.exe'
 
-# Start-CheckandStop 'jellyfin'
-
-if (Test-Path $ENV:ChocolateyToolsLocation\jellyfin){
-    Write-Host "  ** You are upgrading from Jellyfin v10.3.7 PORTABLE." -Foreground Magenta
+if (Test-Path $ENV:ChocolateyToolsLocation\jellyfin) {
+  Write-Host "  ** You are upgrading from Jellyfin v10.3.7 PORTABLE." -Foreground Magenta
 	Write-Host "  ** According to the Jellyfin installation instructions:" -Foreground Magenta
 	Write-Host "  ** ""When using the installer, please ensure you fully uninstall any ZIP archive versions you may have installed," -Foreground Magenta
 	Write-Host "      or you may get duplicate services."""  -Foreground Magenta
 	Write-Host "  ** Please remove $ENV:ChocolateyToolsLocation\jellyfin and install Jellyfin again. Unfortunately you'll also have to configure it again." -Foreground Magenta
 	Uninstall-BinFile 'jellyfin'
 	throw
-	}
+}
 
 $packageArgs = @{
-  packageName    = $packageName
+  packageName    = 'jellyfin'
   fileType       = 'EXE'
-  file64         = "$toolsDir\$installer"
+  url64bit       = "https://github.com/jellyfin/jellyfin/releases/download/$version/jellyfin_$version-x64_windows.exe"
+  checksum64     = '96985faba67f2e3fc0ffa76a4e44ab1b0a274e7feb9860c02db7f6dc254abb30'
+  checksumType64 = 'sha256'
   silentArgs     = '/S'
   validExitCodes = @(0,1)
   softwareName   = 'Jellyfin Server*'
 }
  
-Install-ChocolateyInstallPackage @packageArgs
-
-# if ($ProcessWasRunning -eq "True") {Start-Process $ProcessFullPath}
+Install-ChocolateyPackage @packageArgs
 
 Install-ChocolateyShortcut -shortcutFilePath "$ENV:Public\Desktop\$ShortcutName.lnk" -targetPath "http://localhost:8096" -IconLocation "$ENV:ProgramFiles\Jellyfin\Server\jellyfin-web\favicon.ico"
-
 Install-ChocolateyShortcut -shortcutFilePath "$ENV:ProgramData\Microsoft\Windows\Start Menu\Programs\$ShortcutName.lnk" -targetPath "http://localhost:8096" -IconLocation "$ENV:ProgramFiles\Jellyfin\Server\jellyfin-web\favicon.ico"
 
 Remove-Item $toolsDir\*.exe -EA SilentlyContinue | Out-Null


### PR DESCRIPTION
Also switch to downloading from Github releases, now that official installer binaries are available at a consistent versioned location.

Fixes #156.