### PR TITLE
wrap Add-Type with type existence check

### DIFF
--- a/chocolatey-font-helpers.extension/extensions/MS/Add-Font.ps1
+++ b/chocolatey-font-helpers.extension/extensions/MS/Add-Font.ps1
@@ -397,7 +397,9 @@ namespace FontResource
     }
 }
 '@
-Add-Type $fontCSharpCode
+if (-not ([System.Management.Automation.PSTypeName][FontResource.AddRemoveFonts]).Type) {
+    Add-Type $fontCSharpCode
+}
 
 
 #*******************************************************************

--- a/chocolatey-font-helpers.extension/extensions/MS/Remove-Font.ps1
+++ b/chocolatey-font-helpers.extension/extensions/MS/Remove-Font.ps1
@@ -399,7 +399,9 @@ namespace FontResource
     }
 }
 '@
-Add-Type $fontCSharpCode
+if (-not ([System.Management.Automation.PSTypeName][FontResource.AddRemoveFonts]).Type) {
+    Add-Type $fontCSharpCode
+}
 
 
 #*******************************************************************


### PR DESCRIPTION
@bcurran3 - [grabbed this type existence check from SO](https://stackoverflow.com/questions/16552801/how-do-i-conditionally-add-a-class-with-add-type-typedefinition-if-it-isnt-add) - what do you think?

Should resolve the issue I'm seeing when trying to install multiple choco font packages in a single Boxstarter session and otherwise preserve the functionality when using plain old choco ...

**Note I haven't tested locally - I know a big no-no - just pushing this up for you to consider**

#215 