### PR TITLE
vmware-tools - v11.2.5.17337674

### DIFF
--- a/vmware-tools/vmware-tools_11.2.5.17337674/readme.md
+++ b/vmware-tools/vmware-tools_11.2.5.17337674/readme.md
@@ -1,0 +1,26 @@
+**BCURRAN3'S PACKAGE NOTES:**
+
+* This package downloads the installer via a version specific URL. It should never fail unless the version is completely removed from the vendor website.
+* "REBOOT=R" argument implemented supress reboots.
+* "ADDLOCAL=ALL" argument implemented complete install.
+* I personally use and endorse this program.
+
+***
+
+Like my [original Chocolatey add-ons and packages](https://chocolatey.org/search?q=tag%3Abcurran3)? or my [400+ other program packages](https://chocolatey.org/profiles/bcurran3)? Find them useful? Appreciate my hard work, time, and effort?
+
+
+<h1>How about buying me a <img src="https://cdn.rawgit.com/bcurran3/ChocolateyPackages/master/mylogos/beer.png" alt="" width="40" height="40"> via PayPal?</h1>
+
+[![PayPal Donate](https://www.paypalobjects.com/webstatic/mktg/logo/AM_SbyPP_mc_vs_dc_ae.jpg)](https://www.paypal.me/bcurran3donations)
+
+<h1>Better yet... Keep me incentivized by Patreonizing me!</h1>
+
+[![Patreonize me!](https://c5.patreon.com/external/logo/downloads_wordmark_white_on_coral.png)](https://www.patreon.com/bcurran3)
+
+
+If applicable, please always consider donating or purchasing the software you installed - including [Chocolatey's licensed editions](https://chocolatey.org/pricing).
+
+<h3>TIA,</h3>
+
+<h3>Bill</h3>

--- a/vmware-tools/vmware-tools_11.2.5.17337674/tools/ChocolateyInstall.ps1
+++ b/vmware-tools/vmware-tools_11.2.5.17337674/tools/ChocolateyInstall.ps1
@@ -1,0 +1,48 @@
+﻿# https://packages.vmware.com/tools/releases
+
+$ErrorActionPreference = 'Stop'
+$packageName           = 'vmware-tools'
+$toolsDir              = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url                   = 'https://packages.vmware.com/tools/releases/11.2.5/windows/x86/VMware-tools-11.2.5-17337674-i386.exe'
+$checksum              = '4574457C1D8B45C29C4890B736644D49CC0FC544BCEC653ADEFFF6AADCA67F7B'
+$url64                 = 'https://packages.vmware.com/tools/releases/11.2.5/windows/x64/VMware-tools-11.2.5-17337674-x86_64.exe'
+$checksum64            = '647AF568B8A45FD79DB3717186B4F7037ACA2990F74E641C3F50B107829F96E3'
+$pp                    = Get-PackageParameters
+
+if ( $pp.ALL ) {
+        Write-Host "`nPerforming a Complete installation of VMware Tools...`n" -ForegroundColor Yellow
+        
+        $packageArgs = @{
+          packageName    = $packageName
+          fileType       = 'EXE'
+          url            = $url
+          url64bit       = $url64
+          validExitCodes = @(0, 3010)
+          silentArgs     = '/S /v /qn REBOOT=R ADDLOCAL=ALL'
+          softwareName   = 'VMware Tools'
+          checksum       = $checksum 
+          checksumType   = 'sha256' 
+          checksum64     = $checksum64
+          checksumType64 = 'sha256'
+        }
+
+        Install-ChocolateyPackage @packageArgs
+} else {
+        Write-Host "`nPerforming a Typical installation of VMware Tools...`n" -ForegroundColor Yellow
+        
+        $packageArgs = @{
+          packageName    = $packageName
+          fileType       = 'EXE'
+          url            = $url
+          url64bit       = $url64
+          validExitCodes = @(0, 3010)
+          silentArgs     = '/S /v /qn REBOOT=R'
+          softwareName   = 'VMware Tools'
+          checksum       = $checksum 
+          checksumType   = 'sha256' 
+          checksum64     = $checksum64
+          checksumType64 = 'sha256'
+        }
+
+        Install-ChocolateyPackage @packageArgs
+}

--- a/vmware-tools/vmware-tools_11.2.5.17337674/vmware-tools.nuspec
+++ b/vmware-tools/vmware-tools_11.2.5.17337674/vmware-tools.nuspec
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>vmware-tools</id>
+    <version>11.2.5.17337674</version>
+    <owners>bcurran3 virtualex</owners>
+    <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/vmware-tools</packageSourceUrl>
+    <title>VMWare Tools for Windows (Install)</title>
+    <authors> VMware, Inc</authors>
+    <projectUrl>https://kb.vmware.com/kb/340</projectUrl>
+    <iconUrl>https://cdn.staticaly.com/gh/bcurran3/ChocolateyPackages/master/vmware-tools/vmware-tools_icon.png</iconUrl>
+    <copyright>© 2021 VMware, Inc</copyright>
+    <licenseUrl>https://www.vmware.com/download/eula/universal_eula.html</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <docsUrl>https://www.vmware.com/pdf/vmware-tools-installation-configuration.pdf</docsUrl>
+    <mailingListUrl>https://communities.vmware.com/welcome</mailingListUrl>
+    <tags>vmware vsphere esxi tools</tags>
+    <summary>Windows system utilities for VMs running under VSphere</summary>
+    <description>
+---
+
+### [choco://vmware-tools](choco://vmware-tools)
+To use choco:// protocol URLs, install [(unofficial) choco:// Protocol support ](https://chocolatey.org/packages/choco-protocol-support)
+
+---
+
+### Package Parameters
+* `/ALL` - Performs a Complete Install of VMware Tools (Optional)
+Example: `choco install vmware-tools --params "/ALL"`
+
+### Overview of VMware Tools
+VMware Tools is a suite of utilities that enhances the performance of the virtual machines guest operating system and improves management of the virtual machine. Without VMware Tools installed in your guest operating system, guest performance lacks important functionality. Installing VMware Tools eliminates or improves these issues:
+* Low video resolution
+* Inadequate color depth
+* Incorrect display of network speed
+* Restricted movement of the mouse
+* Inability to copy and paste and drag-and-drop files
+* Missing sound
+* Provides the ability to take quiesced snapshots of the guest OS
+* Synchronizes the time in the guest operating system with the time on the host
+
+VMware Tools includes these components:
+* VMware Tools service
+* VMware device drivers
+* VMware user process
+* VMware Tools control panel	
+
+**[PACKAGE NOTES](https://github.com/bcurran3/ChocolateyPackages/blob/master/vmware-tools/readme.md)**
+
+    
+
+---
+
+**Click here to [Patreon-ize](https://www.patreon.com/bcurran3) the package maintainer.**
+
+---
+
+    </description>
+    <releaseNotes>https://docs.vmware.com/en/VMware-Tools/11.2/rn/VMware-Tools-1125-Release-Notes.html</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
Latest release of `vmware-tools` released on 1/12/21.
`Tested: 1/12/21`
![choco-vmtools-test](https://user-images.githubusercontent.com/12056704/104358725-d8b1c780-54dc-11eb-8fb7-a9bdf8c60848.png)