### PR TITLE
Update ChocolateyInstall.ps1

### DIFF
--- a/wsl-ubuntu-1804/tools/ChocolateyInstall.ps1
+++ b/wsl-ubuntu-1804/tools/ChocolateyInstall.ps1
@@ -2,7 +2,7 @@
 $packageName    = 'wsl-ubuntu-1804'
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url            = 'https://aka.ms/wsl-ubuntu-1804'
-$checksum       = '96E4E3E336F08DDE1DF81FA9C266C5C7750BA92729857E92BDE36BF84A1DB002'
+$checksum       = '0B1ABE8D5DC3FF416A06C9524E4F61A1FDF6CED583CB9B297EE72DF1732FF403'
 $unzipLocation  = "$toolsDir\unzipped"
 $exe            = "ubuntu1804.exe"
 


### PR DESCRIPTION
When trying to install ubuntu 1804, I got the following error message:

```
Chocolatey v0.10.15
Installing the following packages:
wsl-ubuntu-1804
By installing you accept licenses for the packages.
Progress: Downloading wsl-ubuntu-1804 18.04.1.020181923... 100%
wsl-ubuntu-1804 v18.04.1.020181923 [Approved]
wsl-ubuntu-1804 package files install completed. Performing other installation steps.
Downloading wsl-ubuntu-1804 
  from 'https://aka.ms/wsl-ubuntu-1804'
Progress: 100% - Completed download of C:\Users\travis\AppData\Local\Temp\chocolatey\wsl-ubuntu-1804\18.04.1.020181923\Ubuntu_1804.2019.522.0_x64.appx (221.09 MB).
Download of Ubuntu_1804.2019.522.0_x64.appx (221.09 MB) completed.
Error - hashes do not match. Actual value was '0B1ABE8D5DC3FF416A06C9524E4F61A1FDF6CED583CB9B297EE72DF1732FF403'.
ERROR: Checksum for 'C:\Users\travis\AppData\Local\Temp\chocolatey\wsl-ubuntu-1804\18.04.1.020181923\Ubuntu_1804.2019.522.0_x64.appx' did not meet '96E4E3E336F08DDE1DF81FA9C266C5C7750BA92729857E92BDE36BF84A1DB002' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The install of wsl-ubuntu-1804 was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\wsl-ubuntu-1804\tools\ChocolateyInstall.ps1'.
 See log for details.
```