### PR TITLE
Fix error when displaying free space

### DIFF
--- a/choco-cleaner/tools/choco-cleaner.ps1
+++ b/choco-cleaner/tools/choco-cleaner.ps1
@@ -293,9 +293,9 @@ if ($ENV:ChocolateyInstall -Match $ENV:SystemDrive -and $ENV:SystemDrive -eq "C:
     {
      $FreeAfter  = Get-PSDrive C | ForEach-Object {$_.Free}
 	 $FreedSpace = $FreeAfter - $FreeBefore
-     $FreedSpace = $FreedSpace / 1024
-	 $FreedSpace = $FreedSpace.ToString('N0')
+     $FreedSpace = $FreedSpace / 1KB
 	 if ([int]$FreedSpace -lt 0) {$FreedSpace = "0"}
+	 $FreedSpace = $FreedSpace.ToString('N0')
 	 Write-Host Choco-Cleaner finished deleting unnecessary Chocolatey files and reclaimed ~ $FreedSpace KB! -Foreground Magenta
 	 Write-Output "$(Get-Date) Choco-Cleaner FINISHED and reclaimed ~ $FreedSpace KB!" >> "$ENV:ChocolateyToolsLocation\BCURRAN3\choco-cleaner.log"
     } else {


### PR DESCRIPTION
When the number format would use some characters like
NBSP as thousands separator, the cast to `[int]` would fail.
Formatting after all tests fixes this problem.