### PR TITLE
Fix exception when $FreedSpace is less than zero

### DIFF
--- a/choco-cleaner/tools/choco-cleaner.ps1
+++ b/choco-cleaner/tools/choco-cleaner.ps1
@@ -316,7 +316,7 @@ if ($ENV:ChocolateyInstall -Match $ENV:SystemDrive -and $ENV:SystemDrive -eq "C:
      $FreeAfter  = Get-PSDrive C | ForEach-Object {$_.Free}
 	 $FreedSpace = $FreeAfter - $FreeBefore
      $FreedSpace = $FreedSpace / 1KB
-	 if ([int]$FreedSpace -lt 0) {$FreedSpace = "0"}
+	 if ([int]$FreedSpace -lt 0) {$FreedSpace = 0}
 	 $FreedSpace = $FreedSpace.ToString('N0')
 	 Write-Host Choco-Cleaner finished deleting unnecessary Chocolatey files and reclaimed ~ $FreedSpace KB! -Foreground Magenta
 	 Write-Output "$(Get-Date) Choco-Cleaner FINISHED and reclaimed ~ $FreedSpace KB!" >> "$ENV:ChocolateyToolsLocation\BCURRAN3\choco-cleaner.log"


### PR DESCRIPTION
This fixes the exception when `$FreedSpace` variable is less than zero.

*Exception:*
![choco](https://user-images.githubusercontent.com/16168755/119969717-325bef80-bfaf-11eb-8fee-79ce8fd50586.jpg)

*Explanation:*
In case when `$FreedSpace` is less than zero, the `"0"` string is assigned to the variable and string type does not support the `.ToString(string format)` overload.

![choco2](https://user-images.githubusercontent.com/16168755/119969728-3556e000-bfaf-11eb-8845-534d2f694398.jpg)
