### PR TITLE
Update HP UPD PCL/PS to v7.0.0.24832

### DIFF
--- a/hp-universal-print-driver-pcl/hp-universal-print-driver-pcl.nuspec
+++ b/hp-universal-print-driver-pcl/hp-universal-print-driver-pcl.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hp-universal-print-driver-pcl</id>
-    <version>6.8.0.24296</version>
+    <version>7.0.0.24832</version>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/hp-universal-print-driver-pcl</packageSourceUrl>
     <title>HP Universal Print Driver for Windows PCL (Install)</title>

--- a/hp-universal-print-driver-pcl/tools/chocolateyinstall.ps1
+++ b/hp-universal-print-driver-pcl/tools/chocolateyinstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageName    = 'hp-universal-print-driver-pcl' 
-$url            = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99353-22/upd-pcl6-x32-6.8.0.24296.exe'
-$checksum       = 'BAC72F2B1CD16B4198A7054669058AFA42A28BBD32561C68F7AE2939F2BEF78F'
-$url64          = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99374-22/upd-pcl6-x64-6.8.0.24296.exe'
-$checksum64     = '3A47D358C7943044AFE3381460AD4A7FE73B508C50EA63B5419528EDD8932E7B'
+$url            = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99353-23/upd-pcl6-x32-7.0.0.24832.exe'
+$checksum       = '746D1EACADD2C4502E5C403724F43DA9FE06B0CB20FD172F9AD90EC3618A6D7F'
+$url64          = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99374-23/upd-pcl6-x64-7.0.0.24832.exe'
+$checksum64     = 'B6AA40D5A55946EE974E00E197F6AE00C0A397000E08D43851241E37D899E670'
 $softwareName   = ''
 $fileLocation   = "$toolsDir\unzippedfiles\install.exe"
 
@@ -12,7 +12,7 @@ $fileLocation   = "$toolsDir\unzippedfiles\install.exe"
 try {
   $serviceName = 'Spooler'
   $spoolerService = Get-WmiObject -Class Win32_Service -Property StartMode,State -Filter "Name='$serviceName'"
-  if ($spoolerService -eq $null) { throw "Service $serviceName was not found" }
+  if ($null -eq $spoolerService) { throw "Service $serviceName was not found" }
   Write-Host "Print Spooler service state: $($spoolerService.StartMode) / $($spoolerService.State)"
   if ($spoolerService.StartMode -ne 'Auto' -or $spoolerService.State -ne 'Running') {
     Set-Service $serviceName -StartupType Automatic -Status Running
@@ -39,12 +39,12 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs 
 
 $packageArgs = @{
-  packageName   = $packageName
-  fileType      = 'EXE'
-  file          = $fileLocation
-  silentArgs    = '/dm /nd /npf /q /h'
-  validExitCodes= @(0, 3010, 1641)
-  softwareName  = $softwareName
+  packageName    = $packageName
+  fileType       = 'EXE'
+  file           = $fileLocation
+  silentArgs     = '/dm /nd /npf /q /h'
+  validExitCodes = @(0, 3010, 1641)
+  softwareName   = $softwareName
 }
  
 Install-ChocolateyInstallPackage @packageArgs

--- a/hp-universal-print-driver-ps/hp-universal-print-driver-ps.nuspec
+++ b/hp-universal-print-driver-ps/hp-universal-print-driver-ps.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hp-universal-print-driver-ps</id>
-    <version>6.8.0.24296</version>
+    <version>7.0.0.24832</version>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/hp-universal-print-driver-ps</packageSourceUrl>
     <title>HP Universal Print Driver for Windows PS (Install)</title>
@@ -49,14 +49,10 @@ Users are more self-sufficient when the HP UPD is deployed, reducing the need fo
 
 **[PACKAGE NOTES](https://github.com/bcurran3/ChocolateyPackages/blob/master/hp-universal-print-driver-ps/readme.md)**
 
-	
-
----
-
+***
 **Click here to [Patreon-ize](https://www.patreon.com/bcurran3) the package maintainer.**
-
----
-
+***
+	
 </description>
     <releaseNotes>http://h10032.www1.hp.com/ctg/Manual/c03635717</releaseNotes>
   </metadata>

--- a/hp-universal-print-driver-ps/tools/chocolateyinstall.ps1
+++ b/hp-universal-print-driver-ps/tools/chocolateyinstall.ps1
@@ -1,17 +1,18 @@
 ﻿$ErrorActionPreference = 'Stop'
-$packageName    = 'hp-universal-print-driver-ps' 
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url            = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99375-22/upd-ps-x32-6.8.0.24296.exe'
-$checksum       = '7F224595CF4EFBFE6C50B7541FCFB8841A62B304151219433E735897DB3B63D7'
-$url64          = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99376-22/upd-ps-x64-6.8.0.24296.exe'
-$checksum64     = '151FD3746DDD47A1B4DB9C98032F84AAB71AB2D2A957147D32C829421A22E9F6'
+$packageName    = 'hp-universal-print-driver-ps' 
+$url            = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99375-23/upd-ps-x32-7.0.0.24832.exe'
+$checksum       = '6FE7E92692BC66AAA3039CD933910F04D717DFCC65A77B125A0400C2B8F62175'
+$url64          = 'https://ftp.hp.com/pub/softlib/software13/COL40842/ds-99376-23/upd-ps-x64-7.0.0.24832.exe'
+$checksum64     = 'D291D00D9162A76101D307FF531D1CB0FB675A37A97FEF9E695A6400871DC2EE'
+$softwareName   = ''
 $fileLocation   = "$toolsDir\unzippedfiles\install.exe"
 
 # Make sure Print Spooler service is up and running stolen from cutepdf package.
 try {
   $serviceName = 'Spooler'
   $spoolerService = Get-WmiObject -Class Win32_Service -Property StartMode,State -Filter "Name='$serviceName'"
-  if ($spoolerService -eq $null) { throw "Service $serviceName was not found" }
+  if ($null -eq $spoolerService) { throw "Service $serviceName was not found" }
   Write-Host "Print Spooler service state: $($spoolerService.StartMode) / $($spoolerService.State)"
   if ($spoolerService.StartMode -ne 'Auto' -or $spoolerService.State -ne 'Running') {
     Set-Service $serviceName -StartupType Automatic -Status Running
@@ -43,7 +44,7 @@ $packageArgs = @{
   file           = $fileLocation
   silentArgs     = '/dm /nd /npf /q /h'
   validExitCodes = @(0, 3010, 1641)
-  softwareName   = ''
+  softwareName   = $softwareName
 }
  
 Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
Updates HP Universal Print Driver (PCL and PS) to v7.0.0.24832
Makes the PCL and PS PowerShell scripts consistent
Fixes a PowerShell linting error, moving $null to the left side of a comparison
Fixes #273