### PR TITLE
Update intel-graphics-driver to latest version

### DIFF
--- a/intel-graphics-driver/tools/ChocolateyInstall.ps1
+++ b/intel-graphics-driver/tools/ChocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName = 'intel-graphics-driver' 
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64       = 'https://downloadmirror.intel.com/685037/igfx_win_101.1069.exe'
+$url64       = 'https://downloadmirror.intel.com/691496/igfx_win_101.1191.exe'
 $checksum64  = '6B57417381A8C62346B9204BF36EA28478D5E8E1C973C7F869B34D46293FD12C'
 
 if (!(Get-IsWin10)){


### PR DESCRIPTION
See https://www.intel.com/content/www/us/en/download/19344/intel-graphics-windows-dch-drivers.html.

Latest version is now v30.0.101.1191 released on 12/14/2021.

Checksum remained the same (thought this was odd?)