### PR TITLE
Fix incorrect Get-OSArchitectureWidth comparison

### DIFF
--- a/snappy-driver-installer/snappy-driver-installer.nuspec
+++ b/snappy-driver-installer/snappy-driver-installer.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>snappy-driver-installer</id>
-    <version>1.0.539.20170422</version>
+    <version>1.0.539.20220602</version>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/snappy-driver-installer</packageSourceUrl>
     <title>Snappy Driver Installer (Portable)</title>

--- a/snappy-driver-installer/snappy-driver-installer.nuspec
+++ b/snappy-driver-installer/snappy-driver-installer.nuspec
@@ -3,16 +3,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>snappy-driver-installer</id>
-    <version>1.0.539.20220602</version>
+    <version>1.22.1</version>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/snappy-driver-installer</packageSourceUrl>
     <title>Snappy Driver Installer (Portable)</title>
     <authors>Sam Bounce</authors>
     <projectUrl>http://www.sdi-tool.org/</projectUrl>
     <iconUrl>https://sourceforge.net/p/snappy-driver-installer/icon?1426233068</iconUrl>
-    <licenseUrl>https://sourceforge.net/p/snappy-driver-installer/code/HEAD/tree/branches/stable/resources/gpl-3.0.txt</licenseUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://sourceforge.net/p/snappy-driver-installer/code/</projectSourceUrl>
     <docsUrl>http://www.sdi-tool.org/settings/</docsUrl>
     <mailingListUrl>https://sourceforge.net/p/snappy-driver-installer/discussion/</mailingListUrl>
     <bugTrackerUrl>https://sourceforge.net/p/snappy-driver-installer/tickets/</bugTrackerUrl>

--- a/snappy-driver-installer/tools/chocolateyinstall.ps1
+++ b/snappy-driver-installer/tools/chocolateyinstall.ps1
@@ -20,7 +20,7 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 
-if (Get-OSArchitectureWidth -eq 64)
+if (Get-OSArchitectureWidth -Compare 64)
     {
    Install-ChocolateyShortcut -shortcutFilePath "$env:Public\Desktop\$shortcutName.lnk" -targetPath $FileFullpath64 -WorkingDirectory "$toolsDir"
    Install-ChocolateyShortcut -shortcutFilePath "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\$shortcutName.lnk" -targetPath $FileFullpath64

--- a/snappy-driver-installer/tools/chocolateyinstall.ps1
+++ b/snappy-driver-installer/tools/chocolateyinstall.ps1
@@ -1,12 +1,12 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName     = 'snappy-driver-installer' 
 $toolsDir        = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url             = 'https://svwh.dl.sourceforge.net/project/snappy-driver-installer/SDI_R539.zip' 
-$checksum        = '2B430EFE794ABDAB7DB446EF3DA9BFA5979DAE15280B1E8C8BF50EC77400F4CE'
-$fileName32      = 'SDI_RR539.exe'
-$fileName64      = 'SDI_x64_R539.exe'
-$FileFullpath32  = Join-Path $ToolsDir\SDI_R539 $fileName32
-$FileFullpath64  = Join-Path $ToolsDir\SDI_R539 $fileName64
+$url             = 'https://sdi-tool.org/releases/SDI_R2201.zip' 
+$checksum        = '44BFE7243DD089F4886545E05EBE7AEBC9ED2BA492E648FD73C53945B0703FCA'
+$fileName32      = 'SDI_R2201.exe'
+$fileName64      = 'SDI_x64_R2201.exe'
+$FileFullpath32  = Join-Path $ToolsDir $fileName32
+$FileFullpath64  = Join-Path $ToolsDir $fileName64
 $shortcutName    = 'Snappy Driver Installer' 
 
 $packageArgs = @{

--- a/teamspeak-server/teamspeak-server.nuspec
+++ b/teamspeak-server/teamspeak-server.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>teamspeak-server</id>
-    <version>3.13.6.20220602</version>
+    <version>3.13.7</version>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/teamspeak-server</packageSourceUrl>
     <title>TeamSpeak Server</title>
@@ -14,8 +14,8 @@
     <licenseUrl>https://www.teamspeak.com/en/features/licensing/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://teamspeak.com/en/support/get-started/</docsUrl>
-    <mailingListUrl>https://forum.teamspeak.com/</mailingListUrl>
-    <bugTrackerUrl>https://forum.teamspeak.com/forums/120-Bug-Reports-EN-DE</bugTrackerUrl>
+    <mailingListUrl>https://community.teamspeak.com/</mailingListUrl>
+    <bugTrackerUrl>https://community.teamspeak.com/c/teamspeak-server/server-feedback/18</bugTrackerUrl>
     <tags>teamspeak server team speak ts3 ts voip discord mumble ventrilo portable</tags>
     <summary>TeamSpeak is VoIP software designed with security in mind, featuring crystal clear voice quality, scalabilty up to thousands of simultaneous users and endless customization options. Packed with powerful features and incredible performance, TeamSpeak is your Swiss Army Knife of voice communication.</summary>
     <description>

--- a/teamspeak-server/teamspeak-server.nuspec
+++ b/teamspeak-server/teamspeak-server.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>teamspeak-server</id>
-    <version>3.13.6</version>
+    <version>3.13.6.20220602</version>
     <owners>bcurran3</owners>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/teamspeak-server</packageSourceUrl>
     <title>TeamSpeak Server</title>

--- a/teamspeak-server/tools/chocolateyinstall.ps1
+++ b/teamspeak-server/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url          = 'https://files.teamspeak-services.com/releases/server/3.13.6/teamspeak3-server_win32-3.13.6.zip'
-$checksum     = 'f52cddfd2f1297756afa12d758718b3ee34b88c0e7962fb75985877f480e0d71'
-$url64        = 'https://files.teamspeak-services.com/releases/server/3.13.6/teamspeak3-server_win64-3.13.6.zip'
-$checksum64   = '6ffe2fad26cd68cbd8c23f7361469f7eaba9b267f320daf9cce90ed28e4b3bca'
+$url          = 'https://files.teamspeak-services.com/releases/server/3.13.7/teamspeak3-server_win32-3.13.7.zip'
+$checksum     = '03ec18e7700d0884d09e6cbb9419cc8ea80736bf5ac82582941bbe8dc81f3d52'
+$url64        = 'https://files.teamspeak-services.com/releases/server/3.13.7/teamspeak3-server_win64-3.13.7.zip'
+$checksum64   = '489f6f02b336f80812ad0307897e072c37042d1c39341e4efbe7c09d1e100f59'
 $shortcutName = 'TeamSpeak Server.lnk'
 $exe          = 'ts3server.exe'
 

--- a/teamspeak-server/tools/chocolateyinstall.ps1
+++ b/teamspeak-server/tools/chocolateyinstall.ps1
@@ -7,7 +7,7 @@ $checksum64   = '6ffe2fad26cd68cbd8c23f7361469f7eaba9b267f320daf9cce90ed28e4b3bc
 $shortcutName = 'TeamSpeak Server.lnk'
 $exe          = 'ts3server.exe'
 
-if ((Get-OSArchitectureWidth -eq 64) -and ($env:chocolateyForceX86 -ne $true))
+if ((Get-OSArchitectureWidth -Compare 64) -and ($env:chocolateyForceX86 -ne $true))
     {
      $workingDir = 'teamspeak3-server_win64'
     } else {


### PR DESCRIPTION
This changeset resolves a subtle install script failure that is only apparent on 32-bit systems. I experienced the exact same issue with a few of my packages, and did a recursive search on my machine for other places this may have happened. As I've previously cloned your repository, a couple of your packages came up.

The gist of it is that `Get-OSArchitectureWidth -eq 64` will effectively ignore the `-eq 64` portion, since `Get-OSArchitectureWidth` is a function and does not recognize `-eq` as a valid parameter. PowerShell will return the numerical address width value (i.e. 32 or 64) instead of performing the intended `bool` comparison. As this will always return a non-zero value, it will trigger the behavior intended for 64-bit systems on 32-bit systems.

This can be fixed by either wrapping `Get-OSArchitectureWidth -eq 64` in parentheses to enable a correct interpretation of the condition, or change `-eq` to the supported `-Compare` parameter to return a `bool` value instead. I opted for the `-Compare` approach, as this isn't dependent on what could otherwise come across as redundant parentheses.

I've bumped the version of both affected packages using package fix notation.