### PR TITLE
Fixes VNC-Viewers url

### DIFF
--- a/vnc-viewer/tools/chocolateyinstall.ps1
+++ b/vnc-viewer/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $packageName    = 'vnc-viewer'
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $bits           = Get-ProcessorBits
 $extractDir     = "$toolsDir\extracted"
-$url            = "https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-$env:ChocolateyPackageVersion-Windows-msi.zip"
+$url            = "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-$env:ChocolateyPackageVersion-Windows-msi.zip"
 $checksum       = '8388696B93B1816DE0A07FE8DEDB6A56413208066CB0293C35E48F44BA4488B3'
 
 $packageArgs = @{


### PR DESCRIPTION
Looks like the current url is no longer valid.  This uses the current valid url.