### PR TITLE
bump duplicati to 2.0.6.3

### DIFF
--- a/duplicati.portable/duplicati.portable.nuspec
+++ b/duplicati.portable/duplicati.portable.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>duplicati.portable</id>
-    <version>2.0.3.3</version>
+    <version>2.0.6.3</version>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/duplicati.portable</packageSourceUrl>	
     <owners>bcurran3</owners>
     <title>Duplicati (Portable)</title>
@@ -36,7 +36,7 @@ Duplicati is a free, open source, backup client that securely stores encrypted, 
 * FTP
 * and more
 
-Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 4.5+ or Mono required).
+Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 4.7.1+ or Mono required).
 
 ###Features
 
@@ -59,7 +59,7 @@ Backup files and folders with strong AES-256 encryption. Save space with increme
 
 
 ###Free software
-Duplicati is free software and open source. You can use Duplicati for free even for commercial purposes. Source code is licensed under LGPL. Duplicati runs under Windows, Linux, MacOS. It requires .NET 4.5 or Mono.
+Duplicati is free software and open source. You can use Duplicati for free even for commercial purposes. Source code is licensed under LGPL. Duplicati runs under Windows, Linux, MacOS. It requires .NET 4.7.1 or Mono.
 
 
 ###Strong encryption
@@ -77,7 +77,7 @@ Duplicati is configured by a web interface that runs in any browser (even mobile
 	</description>
     <releaseNotes>https://github.com/duplicati/duplicati/blob/master/changelog.txt</releaseNotes>
     <dependencies>
-      <dependency id="dotnet4.5" />
+      <dependency id="dotnetfx" />
     </dependencies>
     </metadata>
   <files>

--- a/duplicati.portable/tools/chocolateyinstall.ps1
+++ b/duplicati.portable/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName    = 'duplicati.portable'
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url            = 'https://github.com/duplicati/duplicati/releases/download/v2.0.3.3-2.0.3.3_beta_2018-04-02/duplicati-2.0.3.3_beta_2018-04-02.zip' 
-$checksum       = '492635C8669E7C1538A35460F2C1F5E2739244C2E8CEFF22A3E5F72997D66A7E'
+$url            = 'https://github.com/duplicati/duplicati/releases/download/v2.0.6.3-2.0.6.3_beta_2021-06-17/duplicati-2.0.6.3_beta_2021-06-17.zip' 
+$checksum       = '85A45CE43E0F8050324854F64F130E8967D881C73C3E120CF81028C1F110CB50'
 $validExitCodes = @(0)
 
 

--- a/duplicati/duplicati.nuspec
+++ b/duplicati/duplicati.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>duplicati</id>
-    <version>2.0.4.5</version>
+    <version>2.0.6.3</version>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/duplicati</packageSourceUrl>	
     <owners>bcurran3</owners>
     <title>Duplicati (Install)</title>
@@ -36,7 +36,7 @@ Duplicati is a free, open source, backup client that securely stores encrypted, 
 * FTP
 * and more
 
-Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 4.5+ or Mono required).
+Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 4.7.1+ or Mono required).
 
 ###Features
 
@@ -59,7 +59,7 @@ Backup files and folders with strong AES-256 encryption. Save space with increme
 
 
 ###Free software
-Duplicati is free software and open source. You can use Duplicati for free even for commercial purposes. Source code is licensed under LGPL. Duplicati runs under Windows, Linux, MacOS. It requires .NET 4.5 or Mono.
+Duplicati is free software and open source. You can use Duplicati for free even for commercial purposes. Source code is licensed under LGPL. Duplicati runs under Windows, Linux, MacOS. It requires .NET 4.7.1 or Mono.
 
 
 ###Strong encryption
@@ -81,7 +81,8 @@ Duplicati is configured by a web interface that runs in any browser (even mobile
 	</description>
     <releaseNotes>https://github.com/duplicati/duplicati/blob/master/changelog.txt</releaseNotes>
     <dependencies>
-      <dependency id="dotnet4.5" />
+      <dependency id="vcredist140" />
+      <dependency id="dotnetfx" />
     </dependencies>
     </metadata>
   <files>

--- a/duplicati/tools/chocolateyinstall.ps1
+++ b/duplicati/tools/chocolateyinstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName    = 'duplicati'
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url            = 'https://github.com/duplicati/duplicati/releases/download/v2.0.4.5-2.0.4.5_beta_2018-11-28/duplicati-2.0.4.5_beta_2018-11-28-x86.msi' 
-$checksum       = 'B3C594AF2FB357BBDD7FDA405F02764E3FF89BB69B0F781FD08190A2FE6787D9'
-$url64          = 'https://github.com/duplicati/duplicati/releases/download/v2.0.4.5-2.0.4.5_beta_2018-11-28/duplicati-2.0.4.5_beta_2018-11-28-x64.msi' 
-$checksum64     = 'E5C0FF6E7D3D9B66F37D105AC16EF787331EE7104ADC5813AA23628160829F75'
+$url            = 'https://github.com/duplicati/duplicati/releases/download/v2.0.6.3-2.0.6.3_beta_2021-06-17/duplicati-2.0.6.3_beta_2021-06-17-x86.msi'
+$checksum       = 'EB8BCA03125F37F956BD36BCB6B00D7D3F4D60C1DDBFB6EACCE43C18FE206D04'
+$url64          = 'https://github.com/duplicati/duplicati/releases/download/v2.0.6.3-2.0.6.3_beta_2021-06-17/duplicati-2.0.6.3_beta_2021-06-17-x64.msi'
+$checksum64     = '9A442CED41F0F9A0142618CE04B67D56C49D9E1C215A2FFCC13F8309428E3ABC'
 
 $packageArgs = @{
   packageName    = $packageName


### PR DESCRIPTION
- Changed URLs & Checksums to latest Duplicati beta [version](https://github.com/duplicati/duplicati/releases/tag/v2.0.6.3-2.0.6.3_beta_2021-06-17)
- Added `vcredit140` to duplicati [nuspec](https://github.com/afischer211/my-chocolatey/blob/master/duplicati/duplicati.nuspec)
- Changed dependency to `dotnetfx` for .net version 4.7.1+