### PR TITLE
fix checksum of gfx_win_101.3222_101.2111.exe

### DIFF
--- a/intel-graphics-driver/tools/ChocolateyInstall.ps1
+++ b/intel-graphics-driver/tools/ChocolateyInstall.ps1
@@ -3,7 +3,7 @@ $packageName = 'intel-graphics-driver'
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url64       = 'https://downloadmirror.intel.com/738230/gfx_win_101.3222_101.2111.exe'
 #                                                ^^^^^^ changes  ^^^^^^^^
-$checksum64  = '575D3C957BA0FD3847A73C77A63031448283272185AAA7AD5F73DF21D709ABA1'
+$checksum64  = '7C3670C7FE9E37C1471D28D2C72C2EE181A71CC2C35BD2F49DDC4B1F514B9C31'
 
 if (!(Get-IsWin10)){
     Write-Warning "  ** This version is only for Windows 10 & 11."


### PR DESCRIPTION
It seems the checksum for gfx_win_101.3222_101.2111.exe is off on the latest update.
Please verify the checksum again.