### PR TITLE
updated forticlientvpn version to 6.4.8.1755

### DIFF
--- a/forticlientvpn/tools/chocolateyinstall.ps1
+++ b/forticlientvpn/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName   = 'forticlientvpn'
 $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url           = 'https://d3gpjj9d20n0p3.cloudfront.net/forticlient/downloads/FortiClientVPNSetup_6.2.6.0951.exe'
+$url           = 'https://d3gpjj9d20n0p3.cloudfront.net/forticlient/downloads/FortiClientVPNSetup_6.4.8.1755.exe'
 $checksum      = 'B85F5E9AECC86FF4FBBA25EA064604B48D3CA723FC4AFA7F5CEF3D289E21D84E'
-$url64         = 'https://d3gpjj9d20n0p3.cloudfront.net/forticlient/downloads/FortiClientVPNSetup_6.2.6.0951_x64.exe'
+$url64         = 'https://d3gpjj9d20n0p3.cloudfront.net/forticlient/downloads/FortiClientVPNSetup_6.4.8.1755_x64.exe'
 $checksum64    = '4A0E4D3BB2F969FBBD61D67180604E035D89A44FC1D664B5CBA14368BB3FA671'
 
 $packageArgs = @{


### PR DESCRIPTION
Would be great if we could have the v6.4 client in the chocolately script. Typically unless you have updated your fortinet gear you need to remain using the v6.x version.

We can also add the 7.0.7.0345 build for those who are using the later FortiOS software in their networks.

Is it possible to add these to the "version" list of the chocolately package. Cheers